### PR TITLE
Read Clientkey from url, add form to get it, debug stuff

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}/src"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react_node_ff",
   "version": "0.1.0",
-  "homepage": "https://launchdarkly-labs.github.io/react_qr_app_ld_beginners/",
+  "homepage": "/react_qr_app_ld_beginners/",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.15.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href="%PUBLIC_URL%/">
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link

--- a/src/components/keyForm.js
+++ b/src/components/keyForm.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+function KeyForm() {
+    let url = document.location;
+    let params = new URLSearchParams(url.search);
+    return (
+        <div>
+            <h1>Oops, you need a Client ID (SDK Key)</h1>
+            <p><i>Instructions go here</i></p>
+            <form id="keyForm">
+                <input type="text" name="key" />
+                <button type="submit" onClick={
+                    (e) => {
+                        let key = document.forms["keyForm"]["key"].value;
+                        params.set("clientKey", key);
+                        let queryString = params.toString();
+                        url.search = queryString;
+                        e.preventDefault();
+                        return false;
+                    }  
+                }>Create the URL</button>
+            </form>
+        </div>
+    )
+}
+
+export default KeyForm;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { asyncWithLDProvider } from "launchdarkly-react-client-sdk";
 import { deviceType, osName } from "react-device-detect";
 import getUserId from "./util/getUserId";
 import getClientKey from "./util/getClientKey";
-
+import KeyForm from "./components/keyForm";
 
 // const CLIENTKEY = "63ea528ee871791399779bc8"; // let's update this to be stored in git in the future
 const CLIENT_KEY = getClientKey();
@@ -15,24 +15,34 @@ const CLIENT_KEY = getClientKey();
 let id = getUserId();
 
 (async () => {
-  const LDProvider = await asyncWithLDProvider({
-    clientSideID: CLIENT_KEY,
-    user: {
-      key: id,
-      //dynamically set these custom attributes using the deviceType and osName selectors from the npm package
-      custom: {
-        device: deviceType,
-        operatingSystem: osName,
-      },
-    },
-  });
 
-  ReactDOM.render(
-    <LDProvider>
-      <App />
-    </LDProvider>,
-    document.getElementById("root")
-  );
+  if (!CLIENT_KEY) {
+    ReactDOM.render(
+      <div>
+        <KeyForm/>
+      </div>,
+      document.getElementById("root")
+    );    
+  } else {
+    const LDProvider = await asyncWithLDProvider({
+      clientSideID: CLIENT_KEY,
+      user: {
+        key: id,
+        //dynamically set these custom attributes using the deviceType and osName selectors from the npm package
+        custom: {
+          device: deviceType,
+          operatingSystem: osName,
+        },
+      },
+    });
+
+    ReactDOM.render(
+      <LDProvider>
+        <App />
+      </LDProvider>,
+      document.getElementById("root")
+    );
+  }
 })();
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,17 @@ import reportWebVitals from "./reportWebVitals";
 import { asyncWithLDProvider } from "launchdarkly-react-client-sdk";
 import { deviceType, osName } from "react-device-detect";
 import getUserId from "./util/getUserId";
+import getClientKey from "./util/getClientKey";
 
-const CLIENTKEY = "63ea528ee871791399779bc8"; // let's update this to be stored in git in the future
+
+// const CLIENTKEY = "63ea528ee871791399779bc8"; // let's update this to be stored in git in the future
+const CLIENT_KEY = getClientKey();
 
 let id = getUserId();
 
 (async () => {
   const LDProvider = await asyncWithLDProvider({
-    clientSideID: CLIENTKEY,
+    clientSideID: CLIENT_KEY,
     user: {
       key: id,
       //dynamically set these custom attributes using the deviceType and osName selectors from the npm package

--- a/src/util/getClientKey.js
+++ b/src/util/getClientKey.js
@@ -1,0 +1,10 @@
+function getClientKey() {
+    let params = new URLSearchParams(document.location.search);
+    let clientKey = params.get('clientKey') || params.get('clientkey');
+    if (!clientKey) {
+        window.alert('No client key found in URL');
+    }
+    return clientKey;
+}
+
+export default getClientKey;

--- a/src/util/getClientKey.js
+++ b/src/util/getClientKey.js
@@ -1,9 +1,6 @@
 function getClientKey() {
     let params = new URLSearchParams(document.location.search);
     let clientKey = params.get('clientKey') || params.get('clientkey');
-    if (!clientKey) {
-        window.alert('No client key found in URL');
-    }
     return clientKey;
 }
 


### PR DESCRIPTION
Changes:

 * Added a VSCode `launch.json` for easier debugging. _DEATH TO CONSOLE.LOG_
 * Reads `CLIENT_KEY` from the `clientKey` URL parameter instead of a hardcoded config
 * If `clientKey` is missing, shows a form which asks for it and redirects to the correct URL