### PR TITLE
Remove hardcoded URL for QR code

### DIFF
--- a/src/components/qrCode.js
+++ b/src/components/qrCode.js
@@ -1,8 +1,8 @@
 import QRCode from "react-qr-code";
 import { withLDConsumer } from "launchdarkly-react-client-sdk";
 
-//Change QRURL to the URL where you'll be hosting this app
-const QRURL = "https://launchdarkly-labs.github.io/react_qr_app_ld_beginners/";
+// No more hard-coding: just use the current URL
+let QR_URL = document.location.toString();
 
 const qrCodeHome = ({ flags }) => {
 
@@ -13,7 +13,7 @@ const qrCodeHome = ({ flags }) => {
       <br />
       <span style={{ color: 'black' }}><center>Scan me!</center></span>
       <div className="qr-wrapper">
-        <QRCode value={QRURL} />
+        <QRCode value={QR_URL} />
       </div>
     </div>
   ) : (


### PR DESCRIPTION
use browser's current location instead